### PR TITLE
fix: Add another parser for array to string

### DIFF
--- a/Command/ConfigSynchronizeCommand.php
+++ b/Command/ConfigSynchronizeCommand.php
@@ -83,11 +83,13 @@ class ConfigSynchronizeCommand extends Command
         $this->output->writeln('---------------------------------------');
         foreach ($config as $key => $value) {
             $currentValue = $this->systemConfigService->get($key, $salesChannelId);
-            $this->output->writeln(sprintf('Current value: "%s" for key: "%s"', $currentValue, $key));
+            $strValue = $this->valueToString($value);
+            $strCurrentValue = $this->valueToString($currentValue);
+            $this->output->writeln(sprintf('Current value: "%s" for key: "%s"', $strCurrentValue, $key));
             // using string comparison for all values (array|bool|float|int|string|null) simplified
-            if ((string) $currentValue !== (string) $value) {
+            if ($strCurrentValue !== $strValue) {
                 $this->systemConfigService->set($key, $value, $salesChannelId);
-                $this->output->writeln(sprintf('Changed value to: "%s" for key: "%s"', $value, $key));
+                $this->output->writeln(sprintf('Changed value to: "%s" for key: "%s"', $strValue, $key));
             } else {
                 $this->output->writeln(sprintf('Did not changed the value for key: "%s"', $key));
             }
@@ -133,5 +135,14 @@ class ConfigSynchronizeCommand extends Command
         }
 
         return $salesChannels;
+    }
+
+    private function valueToString($value): string
+    {
+        if (is_array($value)) {
+            return implode(', ', $value);
+        }
+
+        return (string) $value;
     }
 }

--- a/Command/ConfigSynchronizeCommand.php
+++ b/Command/ConfigSynchronizeCommand.php
@@ -83,13 +83,13 @@ class ConfigSynchronizeCommand extends Command
         $this->output->writeln('---------------------------------------');
         foreach ($config as $key => $value) {
             $currentValue = $this->systemConfigService->get($key, $salesChannelId);
-            $strValue = $this->valueToString($value);
-            $strCurrentValue = $this->valueToString($currentValue);
-            $this->output->writeln(sprintf('Current value: "%s" for key: "%s"', $strCurrentValue, $key));
+            $currentValueAsString = $this->valueToString($currentValue);
+            $valueAsString = $this->valueToString($value);
+            $this->output->writeln(sprintf('Current value: "%s" for key: "%s"', $currentValueAsString, $key));
             // using string comparison for all values (array|bool|float|int|string|null) simplified
-            if ($strCurrentValue !== $strValue) {
+            if ($currentValueAsString !== $valueAsString) {
                 $this->systemConfigService->set($key, $value, $salesChannelId);
-                $this->output->writeln(sprintf('Changed value to: "%s" for key: "%s"', $strValue, $key));
+                $this->output->writeln(sprintf('Changed value to: "%s" for key: "%s"', $valueAsString, $key));
             } else {
                 $this->output->writeln(sprintf('Did not changed the value for key: "%s"', $key));
             }


### PR DESCRIPTION
![Auswahl_151](https://user-images.githubusercontent.com/32621213/159519952-166cb485-5e7e-44e9-9167-66e2a9cb5d3a.png)

To solve error with parsing an array to a string we added an parser which handles an array separately.
Because the version `(string) $currentValue` throws and warning and `strval()` doesn't work with arrays we decided to implement a separate way for arrays.

Refs: ELSSHOP-23