### PR TITLE
Add commands to synchronize apps

### DIFF
--- a/Command/AppSynchronizeCommand.php
+++ b/Command/AppSynchronizeCommand.php
@@ -74,7 +74,7 @@ class AppSynchronizeCommand extends Command
         foreach ($disabledPlugins as $disabledPlugin) {
             $this->runCommand([
                 'command' => 'app:uninstall',
-                'apps' => [$disabledPlugin],
+                'name' => $disabledPlugin,
             ], $output);
         }
 
@@ -116,7 +116,7 @@ class AppSynchronizeCommand extends Command
         try {
             $this->runCommand([
                 'command' => 'app:install',
-                'name' => [$enabledPlugin],
+                'name' => $enabledPlugin,
                 '--activate' => true,
                 '--force' => true,
             ], $output);

--- a/Command/AppSynchronizeCommand.php
+++ b/Command/AppSynchronizeCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flagbit\Shopware\ShopwareMaintenance\Command;
+
+use Exception;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:sync',
+    description: 'Install/uninstall apps as defined in file config/apps.php',
+)]
+class AppSynchronizeCommand extends Command
+{
+    private const CONFIG_FILE_PATH = '/config/apps.php';
+
+    private string $projectDir;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        string $projectDir,
+        LoggerInterface $logger
+    ) {
+        parent::__construct();
+        $this->projectDir = $projectDir;
+        $this->logger = $logger;
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!file_exists($this->projectDir . self::CONFIG_FILE_PATH)) {
+            $output->writeln(sprintf('%s not found', $this->projectDir . self::CONFIG_FILE_PATH));
+
+            return 1;
+        }
+
+        $apps = require $this->projectDir . self::CONFIG_FILE_PATH;
+
+        $errorSum = $this->installUninstallApps($apps, $output);
+
+        if ($errorSum > 0) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param array<string, array<string, bool>> $plugins
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    private function installUninstallApps(array $apps, OutputInterface $output): int
+    {
+        $disabledPlugins = array_keys(array_filter($apps, function ($isEnabled) {
+            return $isEnabled === false;
+        }));
+        $enabledPlugins = array_keys(array_filter($apps, function ($isEnabled) {
+            return $isEnabled === true;
+        }));
+
+        foreach ($disabledPlugins as $disabledPlugin) {
+            $this->runCommand([
+                'command' => 'app:uninstall',
+                'apps' => [$disabledPlugin],
+            ], $output);
+        }
+
+        $installFailed = []; // 0 = install fine, 1 = install failed
+        foreach ($enabledPlugins as $enabledPlugin) {
+            $installFailed[$enabledPlugin] = $this->executeAppInstall($enabledPlugin, $output);
+        }
+
+        return array_sum($installFailed);
+    }
+
+    /**
+     * @param array $parameters
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return int
+     * @throws \Symfony\Component\Console\Exception\ExceptionInterface
+     */
+    private function runCommand(array $parameters, OutputInterface $output): int
+    {
+        $application = $this->getApplication();
+        if ($application === null) {
+            throw new \RuntimeException('No application initialised');
+        }
+
+        $output->writeln('');
+
+        $command = $application->find($parameters['command']);
+        unset($parameters['command']);
+
+        $input = new ArrayInput($parameters);
+        $input->setInteractive(false);
+
+        return $command->run($input, $output);
+    }
+
+    private function executeAppInstall(string $enabledPlugin, OutputInterface $output): int
+    {
+        try {
+            $this->runCommand([
+                'command' => 'app:install',
+                'name' => [$enabledPlugin],
+                '--activate' => true,
+                '--force' => true,
+            ], $output);
+        } catch (Exception $e) {
+            $this->logger->error('Error while installing app: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/Command/AppSynchronizeCommand.php
+++ b/Command/AppSynchronizeCommand.php
@@ -20,6 +20,17 @@ use Symfony\Component\Filesystem\Path;
 )]
 class AppSynchronizeCommand extends Command
 {
+    public const GROUP_CORE = 'core';
+    public const GROUP_THIRD_PARTY = 'third_party';
+    public const GROUP_AGENCY = 'agency';
+    public const GROUP_PROJECT = 'project';
+    private const SEQUENTIAL_GROUPS = [
+        self::GROUP_CORE,
+        self::GROUP_THIRD_PARTY,
+        self::GROUP_AGENCY,
+        self::GROUP_PROJECT,
+    ];
+
     private const CONFIG_FILE_PATH = 'config/apps.php';
 
     private string $projectDir;
@@ -46,12 +57,15 @@ class AppSynchronizeCommand extends Command
             return self::FAILURE;
         }
 
-        $apps = require $configPath;
-        if (!is_array($apps)) {
+        $appGroups = require $configPath;
+        if (!is_array($appGroups)) {
             throw new \RuntimeException('Invalid apps config: expected array');
         }
 
-        $errorSum = $this->installUninstallApps($apps, $output);
+        $errorSum = 0;
+        foreach (self::SEQUENTIAL_GROUPS as $group) {
+            $errorSum += $this->installUninstallAppGroup($appGroups, $group, $output);
+        }
 
         if ($errorSum > 0) {
             return self::FAILURE;
@@ -61,16 +75,37 @@ class AppSynchronizeCommand extends Command
     }
 
     /**
-     * @param array<string, array<string, bool>> $apps
+     * @param array<string, array<string, bool>> $appsGroups
+     * @param string $groupName
      * @param OutputInterface $output
      *
      * @return int
      */
-    private function installUninstallApps(array $apps, OutputInterface $output): int
+    private function installUninstallAppGroup(array $appsGroups, string $groupName, OutputInterface $output): int
     {
+        if (!array_key_exists($groupName, $appsGroups)) {
+            return 0;
+        }
+
+        $apps = $appsGroups[$groupName];
+        if (!is_array($apps)) {
+            throw new \RuntimeException(sprintf(
+                'Invalid apps config for group "%s": expected array',
+                $groupName
+            ));
+        }
+
         $enabledApps = [];
         $disabledApps = [];
         foreach ($apps as $app => $isEnabled) {
+            if (!is_bool($isEnabled)) {
+                throw new \RuntimeException(sprintf(
+                    'Invalid value for app "%s" in group "%s": expected boolean',
+                    $app,
+                    $groupName
+                ));
+            }
+
             if ($isEnabled) {
                 $enabledApps[] = $app;
                 continue;
@@ -79,26 +114,28 @@ class AppSynchronizeCommand extends Command
             $disabledApps[] = $app;
         }
 
-        $uninstallFailed = []; // 0 = uninstall fine, 1 = uninstall failed
+        $uninstallFailed = 0;
         foreach ($disabledApps as $disabledApp) {
-            $uninstallFailed[$disabledApp] = $this->executeAppUninstall($disabledApp, $output);
+            $uninstallFailed += $this->executeAppUninstall($disabledApp, $output);
         }
 
-        $installFailed = []; // 0 = install fine, 1 = install failed
+        $installFailed = 0;
         foreach ($enabledApps as $enabledPlugin) {
-            $installFailed[$enabledPlugin] = $this->executeAppInstall($enabledPlugin, $output);
+            $installFailed += $this->executeAppInstall($enabledPlugin, $output);
         }
 
-        return array_sum($uninstallFailed) + array_sum($installFailed);
+        return $uninstallFailed + $installFailed;
     }
 
-    private function executeAppUninstall(string $disabledPlugin, OutputInterface $output): int
+    private function executeAppUninstall(string $disabledApp, OutputInterface $output): int
     {
         try {
+            $this->logger->info(sprintf('Uninstalling app: %s', $disabledApp));
             $this->runCommand([
                 'command' => 'app:uninstall',
-                'name' => $disabledPlugin,
+                'name' => $disabledApp,
             ], $output);
+            $this->logger->info(sprintf('Successfully uninstalled app: %s', $disabledApp));
         } catch (Exception|ExceptionInterface $e) {
             $this->logger->error('Error while uninstalling app: ' . $e->getMessage());
             return self::FAILURE;
@@ -107,17 +144,20 @@ class AppSynchronizeCommand extends Command
         return self::SUCCESS;
     }
 
-    private function executeAppInstall(string $enabledPlugin, OutputInterface $output): int
+    private function executeAppInstall(string $enabledApp, OutputInterface $output): int
     {
         try {
+            $this->logger->info(sprintf('Installing app: %s', $enabledApp));
             $this->runCommand([
                 'command' => 'app:install',
-                'name' => $enabledPlugin,
+                'name' => $enabledApp,
                 '--activate' => true,
                 '--force' => true,
             ], $output);
+            $this->logger->info(sprintf('Successfully installed app: %s', $enabledApp));
         } catch (Exception|ExceptionInterface $e) {
             $this->logger->error('Error while installing app: ' . $e->getMessage());
+
             return self::FAILURE;
         }
 

--- a/Command/AppSynchronizeCommand.php
+++ b/Command/AppSynchronizeCommand.php
@@ -8,6 +8,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,6 +34,9 @@ class AppSynchronizeCommand extends Command
         $this->logger = $logger;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configPath = Path::join($this->projectDir, self::CONFIG_FILE_PATH);
@@ -43,6 +47,9 @@ class AppSynchronizeCommand extends Command
         }
 
         $apps = require $configPath;
+        if (!is_array($apps)) {
+            throw new \RuntimeException('Invalid apps config: expected array');
+        }
 
         $errorSum = $this->installUninstallApps($apps, $output);
 
@@ -54,41 +61,75 @@ class AppSynchronizeCommand extends Command
     }
 
     /**
-     * @param array<string, array<string, bool>> $plugins
+     * @param array<string, array<string, bool>> $apps
      * @param OutputInterface $output
      *
      * @return int
      */
     private function installUninstallApps(array $apps, OutputInterface $output): int
     {
-        $disabledPlugins = array_keys(array_filter($apps, function ($isEnabled) {
-            return $isEnabled === false;
-        }));
-        $enabledPlugins = array_keys(array_filter($apps, function ($isEnabled) {
-            return $isEnabled === true;
-        }));
+        $enabledApps = [];
+        $disabledApps = [];
+        foreach ($apps as $app => $isEnabled) {
+            if ($isEnabled) {
+                $enabledApps[] = $app;
+                continue;
+            }
 
-        foreach ($disabledPlugins as $disabledPlugin) {
+            $disabledApps[] = $app;
+        }
+
+        $uninstallFailed = []; // 0 = uninstall fine, 1 = uninstall failed
+        foreach ($disabledApps as $disabledApp) {
+            $uninstallFailed[$disabledApp] = $this->executeAppUninstall($disabledApp, $output);
+        }
+
+        $installFailed = []; // 0 = install fine, 1 = install failed
+        foreach ($enabledApps as $enabledPlugin) {
+            $installFailed[$enabledPlugin] = $this->executeAppInstall($enabledPlugin, $output);
+        }
+
+        return array_sum($uninstallFailed) + array_sum($installFailed);
+    }
+
+    private function executeAppUninstall(string $disabledPlugin, OutputInterface $output): int
+    {
+        try {
             $this->runCommand([
                 'command' => 'app:uninstall',
                 'name' => $disabledPlugin,
             ], $output);
+        } catch (Exception|ExceptionInterface $e) {
+            $this->logger->error('Error while uninstalling app: ' . $e->getMessage());
+            return self::FAILURE;
         }
 
-        $installFailed = []; // 0 = install fine, 1 = install failed
-        foreach ($enabledPlugins as $enabledPlugin) {
-            $installFailed[$enabledPlugin] = $this->executeAppInstall($enabledPlugin, $output);
+        return self::SUCCESS;
+    }
+
+    private function executeAppInstall(string $enabledPlugin, OutputInterface $output): int
+    {
+        try {
+            $this->runCommand([
+                'command' => 'app:install',
+                'name' => $enabledPlugin,
+                '--activate' => true,
+                '--force' => true,
+            ], $output);
+        } catch (Exception|ExceptionInterface $e) {
+            $this->logger->error('Error while installing app: ' . $e->getMessage());
+            return self::FAILURE;
         }
 
-        return array_sum($installFailed);
+        return self::SUCCESS;
     }
 
     /**
      * @param array $parameters
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param OutputInterface $output
      *
      * @return int
-     * @throws \Symfony\Component\Console\Exception\ExceptionInterface
+     * @throws ExceptionInterface
      */
     private function runCommand(array $parameters, OutputInterface $output): int
     {
@@ -106,22 +147,5 @@ class AppSynchronizeCommand extends Command
         $input->setInteractive(false);
 
         return $command->run($input, $output);
-    }
-
-    private function executeAppInstall(string $enabledPlugin, OutputInterface $output): int
-    {
-        try {
-            $this->runCommand([
-                'command' => 'app:install',
-                'name' => $enabledPlugin,
-                '--activate' => true,
-                '--force' => true,
-            ], $output);
-        } catch (Exception $e) {
-            $this->logger->error('Error while installing app: ' . $e->getMessage());
-            return self::FAILURE;
-        }
-
-        return self::SUCCESS;
     }
 }

--- a/Command/AppSynchronizeCommand.php
+++ b/Command/AppSynchronizeCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
 
 #[AsCommand(
     name: 'app:sync',
@@ -18,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class AppSynchronizeCommand extends Command
 {
-    private const CONFIG_FILE_PATH = '/config/apps.php';
+    private const CONFIG_FILE_PATH = 'config/apps.php';
 
     private string $projectDir;
     private LoggerInterface $logger;
@@ -32,20 +33,16 @@ class AppSynchronizeCommand extends Command
         $this->logger = $logger;
     }
 
-    protected function configure(): void
-    {
-        parent::configure();
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!file_exists($this->projectDir . self::CONFIG_FILE_PATH)) {
-            $output->writeln(sprintf('%s not found', $this->projectDir . self::CONFIG_FILE_PATH));
+        $configPath = Path::join($this->projectDir, self::CONFIG_FILE_PATH);
+        if (!file_exists($configPath)) {
+            $output->writeln(sprintf('%s not found', $configPath));
 
             return self::FAILURE;
         }
 
-        $apps = require $this->projectDir . self::CONFIG_FILE_PATH;
+        $apps = require $configPath;
 
         $errorSum = $this->installUninstallApps($apps, $output);
 

--- a/Command/AppSynchronizeCommand.php
+++ b/Command/AppSynchronizeCommand.php
@@ -42,7 +42,7 @@ class AppSynchronizeCommand extends Command
         if (!file_exists($this->projectDir . self::CONFIG_FILE_PATH)) {
             $output->writeln(sprintf('%s not found', $this->projectDir . self::CONFIG_FILE_PATH));
 
-            return 1;
+            return self::FAILURE;
         }
 
         $apps = require $this->projectDir . self::CONFIG_FILE_PATH;

--- a/Command/PluginSynchronizeCommand.php
+++ b/Command/PluginSynchronizeCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
 
 #[AsCommand(
     name: 'plugin:sync',
@@ -22,6 +23,8 @@ class PluginSynchronizeCommand extends Command
     public const GROUP_THIRD_PARTY = 'third_party';
     public const GROUP_AGENCY = 'agency';
     public const GROUP_PROJECT = 'project';
+
+    private const CONFIG_FILE_PATH = 'config/plugins.php';
 
     private string $projectDir;
     private LoggerInterface $logger;
@@ -35,20 +38,16 @@ class PluginSynchronizeCommand extends Command
         $this->logger = $logger;
     }
 
-    protected function configure(): void
-    {
-        parent::configure();
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!file_exists($this->projectDir . '/config/plugins.php')) {
-            $output->writeln(sprintf('%s not found', $this->projectDir . '/config/plugins.php'));
+        $configPath = Path::join($this->projectDir . self::CONFIG_FILE_PATH);
+        if (!file_exists($configPath)) {
+            $output->writeln(sprintf('%s not found', $configPath));
 
             return 1;
         }
 
-        $pluginGroups = require $this->projectDir . '/config/plugins.php';
+        $pluginGroups = require $configPath;
 
         $errorSum = $this->installUninstallPluginGroup($pluginGroups, self::GROUP_CORE, $output);
         $errorSum += $this->installUninstallPluginGroup($pluginGroups, self::GROUP_THIRD_PARTY, $output);

--- a/Command/PluginSynchronizeCommand.php
+++ b/Command/PluginSynchronizeCommand.php
@@ -40,7 +40,7 @@ class PluginSynchronizeCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $configPath = Path::join($this->projectDir . self::CONFIG_FILE_PATH);
+        $configPath = Path::join($this->projectDir, self::CONFIG_FILE_PATH);
         if (!file_exists($configPath)) {
             $output->writeln(sprintf('%s not found', $configPath));
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ The group `project` is for plugins which are specifically developed for this pro
 ### Install/Uninstall apps
 
 The file `config/apps.php` defines which Shopware apps should be enabled or disabled.
-While installing the plugins the command will accept all permissions and hosts.
+
+> [!CAUTION]
+> While installing the plugins the command will accept all permissions and hosts.
 
 
 **Example**

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ We do not use the **uuid** from the SalesChannel because this can be different f
 bin/console config:sync # synchronizes configuration values as defined in config/config.yaml
 bin/console plugin:refresh # ensure plugins classes are loaded before plugin:sync execution
 bin/console plugin:sync # synchronizes plugin enable/disable status as defined in config/plugins.php  
+bin/console app:sync # synchronizes app enable/disable status as defined in config/apps.php
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ Plugins which are from flagbit but aren't for specific for this project and can 
 ##### Project
 The group `project` is for plugins which are specifically developed for this project.
 
+### Install/Uninstall apps
+
+The file `config/apps.php` defines which Shopware apps should be enabled or disabled.
+While installing the plugins the command will accept all permissions and hosts.
+
+
+**Example**
+
+```php
+# config/apps.php
+
+<?php declare(strict_types=1);
+
+return [
+    'SwagAnalytics' => true,                # enabled
+    'InstoImmersiveElements' => false,      # disbled
+    'DmitsPaymentCostApp' => true,          # enabled
+];
+
+```
+
 ### Define Config
 
 The file `config/config.yaml` defines Shopware plugin configuration values to be set.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,6 +4,12 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Flagbit\Shopware\ShopwareMaintenance\Command\AppSynchronizeCommand">
+            <argument type="string">%kernel.project_dir%</argument>
+            <argument type="service" id="logger"/>
+            <tag name="console.command"/>
+        </service>
+
         <service id="Flagbit\Shopware\ShopwareMaintenance\Command\PluginSynchronizeCommand">
             <argument type="string">%kernel.project_dir%</argument>
             <argument type="service" id="logger"/>

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
         "symfony/framework-bundle": "^6.3|^7.0"
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "symfony/runtime": true
-        }
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,14 @@
         ]
     },
     "require": {
-        "shopware/core": "^6.5|^6.6",
+        "shopware/core": "^6.5|^6.6|^6.7",
         "symfony/console": "^6.3|^7.0",
         "symfony/framework-bundle": "^6.3|^7.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/runtime": true
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces support for synchronizing Shopware apps in addition to plugins. The main feature is a new command for enabling or disabling apps based on the configuration in `config/apps.php`, along with documentation updates and necessary dependency and service registrations.

New app synchronization functionality:

* Added `AppSynchronizeCommand` to provide a `bin/console app:sync` command, which installs or uninstalls apps as defined in `config/apps.php`. The command processes apps in groups and handles errors robustly. (`Command/AppSynchronizeCommand.php`)
* Registered the new command as a Symfony service so it is available in the console. (`Resources/config/services.xml`)

Documentation updates:

* Updated `README.md` to describe the new app synchronization feature, including usage instructions and an example `config/apps.php` file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R114) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142)

Dependency and minor improvements:

* Updated `composer.json` to support Shopware core version 6.7.
* Refactored `PluginSynchronizeCommand` to use the same path handling as the new app command for consistency. (`Command/PluginSynchronizeCommand.php`) [[1]](diffhunk://#diff-47cadd3db85a0823306465e9e45068804aa2bdf134e0f2ad957b9f7842a12db0R14) [[2]](diffhunk://#diff-47cadd3db85a0823306465e9e45068804aa2bdf134e0f2ad957b9f7842a12db0R27-R28) [[3]](diffhunk://#diff-47cadd3db85a0823306465e9e45068804aa2bdf134e0f2ad957b9f7842a12db0L38-R50)

Refs: IS-386